### PR TITLE
Use latest 2022 orthophoto available in Ljubljana

### DIFF
--- a/OsmGursBuildingImport/SimpleTaskManager.cs
+++ b/OsmGursBuildingImport/SimpleTaskManager.cs
@@ -81,7 +81,7 @@ namespace OsmGursBuildingImport
                 josmCommands.Add("http://localhost:8111/imagery?id=GURS-DOF025");
                 if (ljubljana.Intersects(area.Geometry))
                 {
-                    josmCommands.Add("http://localhost:8111/imagery?id=LJUBLJANA-DOF-2020");
+                    josmCommands.Add("http://localhost:8111/imagery?id=LJUBLJANA-DOF-2022");
                 }
 
                 josmCommands.Add("http://localhost:8111/imagery?id=GURS-buildings");


### PR DESCRIPTION
https://josm.openstreetmap.de/wiki/Maps/Slovenia#Ljubljana:Orthophoto2022WMTS